### PR TITLE
[chore] get rid of `ShellClient`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 #![deny(dead_code, unused_variables, unreachable_code, unused_imports)]
 
+use anyhow::bail;
 use clap::Parser;
 pub(crate) mod utils;
-use utils::{args::Args, client::ShellClient};
+use utils::{
+    args::{Args, Commands},
+    client::InteractiveCommandClient,
+};
 
 fn main() -> anyhow::Result<()> {
     simple_logger::SimpleLogger::new()
@@ -10,6 +14,19 @@ fn main() -> anyhow::Result<()> {
         .env()
         .init()?;
     let args = Args::parse();
-    // println!("{:#?}", args);
-    ShellClient::call(args)
+    match args.command {
+        Commands::CmdObj {
+            object,
+            function,
+            args,
+            info,
+        } => {
+            let result = InteractiveCommandClient::call(object, function, args, info);
+            match result {
+                Ok(result) => println!("{result:#}"),
+                Err(err) => bail!("{err}"),
+            };
+            Ok(())
+        }
+    }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,12 +1,9 @@
 use anyhow::bail;
 
-use crate::utils::{
-    args::Args,
-    client::{InteractiveCommandClient, ShellClient},
-};
+use crate::utils::client::InteractiveCommandClient;
 
 #[test]
-fn interactive_command_client_x11() -> anyhow::Result<()> {
+fn qtile_info() -> anyhow::Result<()> {
     let ret = InteractiveCommandClient::call(
         Some(vec!["root".to_string()]),
         Some("qtile_info".to_string()),
@@ -18,17 +15,4 @@ fn interactive_command_client_x11() -> anyhow::Result<()> {
         Err(e) => bail!(e),
     }
     Ok(())
-}
-
-#[test]
-fn shell_client_x11() -> anyhow::Result<()> {
-    let args = Args {
-        command: crate::utils::args::Commands::CmdObj {
-            object: None,
-            function: Some("qtile_info".to_owned()),
-            args: None,
-            info: false,
-        },
-    };
-    ShellClient::call(args)
 }

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -1,30 +1,8 @@
-use super::{args::Args, ipc::Client, parser::CommandParser};
-use anyhow::bail;
+use super::{ipc::Client, parser::CommandParser};
 use serde_json::Value;
 
-/// Client used for CLI by `qticc` binary
-pub struct ShellClient {}
-
-impl ShellClient {
-    /// construct a [`CommandParser`] from CLI args and [`serialize`](serde_tuple::Serialize_tuple) it into a tuple string for sending over the qtile socket
-    pub fn call(args: Args) -> anyhow::Result<()> {
-        let c = CommandParser::from_args(args.clone())?;
-        let data = serde_json::to_string(&c).unwrap();
-        let response = Client::send(data.clone());
-        let result = Client::match_response(response);
-        match result {
-            Ok(result) => println!("{result:#}"),
-            Err(err) => bail!("{err}"),
-        }
-        Ok(())
-    }
-    // pub fn
-}
-
 /// Client used by library for executing qtile commands
-#[allow(dead_code)]
 pub struct InteractiveCommandClient {}
-#[allow(dead_code)]
 impl InteractiveCommandClient {
     /// construct a [`CommandParser`] from parameters and [`serialize`](serde_tuple::Serialize_tuple) it into a tuple string for sending over the qtile socket
     pub fn call(

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -12,8 +12,6 @@ use serde_tuple::Serialize_tuple;
 use std::{collections::HashMap, process::exit, str::FromStr};
 use strum::Display;
 
-use super::args::{Args, Commands};
-
 #[derive(PartialEq, Debug, Display)]
 pub(crate) enum NumberOrString {
     Uint(u32),
@@ -56,23 +54,6 @@ pub struct CommandParser {
 }
 
 impl CommandParser {
-    /// Destructure command from CLI into parameters and create a new Self using [`Self::from_params`]
-    pub fn from_args(cli_args: Args) -> anyhow::Result<Self> {
-        // let graph_node: CommandGraphNode = CommandGraphNode::new(
-        //     Selector::String("screen".to_string()),
-        //     None,
-        //     NodeType::Object(ObjectType::Screen("screen".to_string(), None)),
-        // );
-        // println!("{:#?}", graph_node);
-        match cli_args.command {
-            Commands::CmdObj {
-                object,
-                function,
-                args,
-                info,
-            } => Self::from_params(object, function, args, info),
-        }
-    }
     ///  Create a new Self from parameters
     pub fn from_params(
         object: Option<Vec<String>>,
@@ -121,12 +102,9 @@ impl CommandParser {
     }
 
     /// Prints help for cmd-obj
-    pub fn print_help(
-        selectors: &Vec<Vec<Value>>,
-        object: Option<Vec<String>>,
-    ) -> anyhow::Result<()> {
+    pub fn print_help(selectors: &[Vec<Value>], object: Option<Vec<String>>) -> anyhow::Result<()> {
         let commands = CommandParser {
-            selectors: selectors.clone(),
+            selectors: selectors.to_owned(),
             command: "commands".to_string(),
             args: vec![],
             kwargs: HashMap::new(),
@@ -145,7 +123,7 @@ impl CommandParser {
                         obj_string = "root".to_owned();
                     }
                     let prefix = "-o ".to_owned() + &obj_string + " -f ";
-                    let printed_commands = Self::print_commands(selectors.clone(), prefix, arr);
+                    let printed_commands = Self::print_commands(selectors.to_owned(), prefix, arr);
                     match printed_commands {
                         Ok(()) => {
                             exit(0);


### PR DESCRIPTION
`ShellClient` was an even higher level of a high level API (`InteractiveCommandClient`) which wasn't needed in the end.