### PR TITLE
fix(deps): gate rustyline behind optional repl feature; downgrade to 17.0.2

### DIFF
--- a/.github/scripts/install-deps
+++ b/.github/scripts/install-deps
@@ -23,7 +23,7 @@ wget -qO "$TEMP_SETUP" "$UPSTREAM_URL"
 export INSTALL_DIR
 if python3 ./.github/scripts/patch_wayland_setup.py "$TEMP_SETUP" /dev/null --check-all; then
   echo "All foundation dependencies found in $INSTALL_DIR (or system). skipping lock and build."
-  
+
   # Ensure Xwayland symlink if found in PVC
   if [ -f "$INSTALL_DIR/bin/Xwayland" ] && [ ! -f "/usr/bin/Xwayland" ]; then
     echo "Creating Xwayland symlink from PVC..."
@@ -71,7 +71,7 @@ acquire_lock() {
       exit 1
     fi
   done
-  
+
   # We successfully created the directory, so we own the lock
   WE_OWN_LOCK=1
 }

--- a/.github/scripts/install-qtile
+++ b/.github/scripts/install-qtile
@@ -9,21 +9,82 @@ QTILE_REPO="${2:-https://github.com/qtile/qtile}"
 # Use provided qtile branch or default to master
 QTILE_BRANCH="${3:-master}"
 
-# Clean up any existing source to ensure a fresh build
-rm -rf qtile-source
+# PVC path for persistent Qtile source and uv tool environment
+QTILE_CACHE_ROOT="${AGENT_TOOLSDIRECTORY:-/tmp}/qtile-cache"
+QTILE_HASH="$(echo "$QTILE_REPO" | md5sum | cut -d' ' -f1)-$QTILE_BRANCH"
+QTILE_SOURCE_DIR="$QTILE_CACHE_ROOT/sources/$QTILE_HASH"
+# Unique tool environment per python version and branch
+TOOL_ENV_DIR="$QTILE_CACHE_ROOT/envs/${QTILE_HASH}-py${PYTHON_VERSION}"
 
-# Clone qtile
-git clone --branch "$QTILE_BRANCH" "$QTILE_REPO" qtile-source
+mkdir -p "$QTILE_CACHE_ROOT/sources" "$QTILE_CACHE_ROOT/envs"
+
+# We must ensure the tool binary is available in the expected location
+mkdir -p "$HOME/.local/bin"
+
+# Acquire a single global lock for this Qtile source branch to prevent concurrent runners
+# (regardless of Python version) from corrupting the git fetch or the virtual environment creation.
+LOCK_DIR="$QTILE_CACHE_ROOT/${QTILE_HASH}.lock"
+acquire_lock() {
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    if [ -d "$LOCK_DIR" ] && [ "$(($(date +%s) - $(stat -c %Y "$LOCK_DIR")))" -gt 1800 ]; then
+      rm -rf "$LOCK_DIR"
+      continue
+    fi
+    sleep $(( (RANDOM % 5) + 1 ))
+  done
+}
+trap 'rm -rf "$LOCK_DIR"' EXIT
+acquire_lock
+
+# Fast path: If the tool environment already exists and qtile works, we just link it and exit
+if [ -d "$TOOL_ENV_DIR" ] && [ -x "$TOOL_ENV_DIR/bin/qtile" ]; then
+  echo "Found cached Qtile environment for Python $PYTHON_VERSION"
+  ln -sf "$TOOL_ENV_DIR/bin/qtile" "$HOME/.local/bin/qtile"
+  if "$HOME/.local/bin/qtile" --version >/dev/null 2>&1; then
+    echo "Cached Qtile works. Skipping build."
+    if getent group video >/dev/null; then
+      sudo usermod -aG video runner || true
+    fi
+    exit 0
+  else
+    echo "Cached Qtile is broken. Rebuilding..."
+    rm -rf "$TOOL_ENV_DIR"
+  fi
+fi
+
+if [ ! -d "$QTILE_SOURCE_DIR" ]; then
+  echo "Cloning Qtile into $QTILE_SOURCE_DIR..."
+  git clone --branch "$QTILE_BRANCH" "$QTILE_REPO" "$QTILE_SOURCE_DIR"
+else
+  echo "Updating existing Qtile source in $QTILE_SOURCE_DIR..."
+  git -C "$QTILE_SOURCE_DIR" fetch origin "$QTILE_BRANCH"
+  git -C "$QTILE_SOURCE_DIR" reset --hard "origin/$QTILE_BRANCH"
+  git -C "$QTILE_SOURCE_DIR" clean -fdx
+fi
+
+# Copy from PVC to local workspace directory 'qtile-source' to build cleanly
+rm -rf qtile-source
+cp -a "$QTILE_SOURCE_DIR/." qtile-source/
 cd qtile-source
 
 export UV_HTTP_TIMEOUT=300
 
-# Sync and build
+# Sync and build in the isolated directory
 uv sync --python="$PYTHON_VERSION" --all-extras
 uv run ./libqtile/backend/wayland/cffi/build.py
 
-# Install qtile as a tool with wayland support and optional dbus-fast
-uv tool install . --with ".[wayland],dbus-fast" --python "$PYTHON_VERSION" --force
+# Install qtile directly into the persistent cache using a virtual environment, not uv tool
+# `uv tool` handles linking magically, which is hard to move. `uv venv` gives us a standard prefix.
+echo "Installing to persistent cache: $TOOL_ENV_DIR"
+uv venv "$TOOL_ENV_DIR" --python="$PYTHON_VERSION"
+uv pip install --python "$TOOL_ENV_DIR/bin/python" ".[wayland,dbus-fast]"
+
+# Cleanup ephemeral source
+cd ..
+rm -rf qtile-source
+
+# Link the persistent binary to the runner's PATH
+ln -sf "$TOOL_ENV_DIR/bin/qtile" "$HOME/.local/bin/qtile"
 
 # Add runner to video group if it exists
 if getent group video >/dev/null; then
@@ -31,4 +92,4 @@ if getent group video >/dev/null; then
 fi
 
 # Ensure qtile is available and report version
-qtile --version
+"$HOME/.local/bin/qtile" --version

--- a/.github/scripts/patch_wayland_setup.py
+++ b/.github/scripts/patch_wayland_setup.py
@@ -7,7 +7,7 @@ import subprocess
 def get_pkg_name(prefix, version):
     """Maps tarball prefix to pkg-config name."""
     version = version.lstrip('v')
-    
+
     mapping = {
         "wayland": "wayland-client",
         "wayland-protocols": "wayland-protocols",
@@ -33,16 +33,16 @@ def check_dependency(pkg, version):
     """Checks if a dependency is satisfied using pkg-config or binary check."""
     version = version.lstrip('v')
     install_dir = os.environ.get("INSTALL_DIR", "")
-    
+
     if pkg == "xwayland":
         installed = get_installed_version("xwayland")
         if not installed:
             return False
-        
+
         # Simple numeric version comparison (e.g. 22.1.9 >= 21.0.0)
         def ver_tuple(v):
             return tuple(map(int, (v.split('.') + [0, 0, 0])[:3]))
-        
+
         try:
             return ver_tuple(installed) >= ver_tuple(version)
         except (ValueError, AttributeError):
@@ -66,12 +66,12 @@ def check_dependency(pkg, version):
 def get_installed_version(pkg):
     """Gets the currently installed version of a package."""
     install_dir = os.environ.get("INSTALL_DIR", "")
-    
+
     if pkg == "xwayland":
         binary = os.path.join(install_dir, "bin/Xwayland")
         if not os.path.exists(binary):
             binary = "/usr/bin/Xwayland"
-        
+
         if os.path.exists(binary):
             try:
                 # Xwayland -version prints to stderr and returns 0
@@ -106,16 +106,16 @@ def parse_dependencies(script_content):
     deps = []
     for match in re.finditer(r'tarball="([^"]+)\.tar\..*?"', script_content):
         full_name = match.group(1)
-        
+
         # Resolve variables safely using regex boundaries ($VAR or ${VAR})
         def replacer(m):
             var_name = m.group(1) or m.group(2)
             return vars.get(var_name, m.group(0))
-            
+
         full_name = re.sub(r'\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([A-Za-z_][A-Za-z0-9_]*)\}', replacer, full_name)
-        
+
         # Now full_name is expanded (e.g. wayland-1.24.0, libdrm-libdrm-2.4.122, 0.6.4, v0.364)
-        
+
         # Some tarballs don't have a prefix (like seatd which is just $SEATD.tar.gz)
         # Or hwdata which is v$HWDATA.tar.gz
         if '-' not in full_name:
@@ -127,22 +127,22 @@ def parse_dependencies(script_content):
                 version = full_name
                 deps.append((prefix, version))
             continue
-            
+
         # Split on the first dash that is followed by a digit or 'v'
         m = re.search(r'^(.*?)-([v0-9].*)$', full_name)
         if not m:
             continue
-            
+
         prefix = m.group(1)
         version = m.group(2)
-        
+
         deps.append((prefix, version))
     return deps
 
 def patch_script(input_path, output_path):
     with open(input_path, 'r') as f:
         content = f.read()
-    
+
     lines = content.splitlines(keepends=True)
 
     # Build the shell-side check logic
@@ -152,7 +152,7 @@ def patch_script(input_path, output_path):
 should_build() {{
     tarball_expr=$1
     base=$(echo "$tarball_expr" | sed 's/\.tar\..*//')
-    
+
     # Check if base has a dash
     if [[ "$base" == *-* ]]; then
         # prefix is everything before the first dash-digit or dash-v
@@ -168,9 +168,9 @@ should_build() {{
             prefix="seatd"
         fi
     fi
-    
+
     clean_v=${{version_str#v}}
-    
+
     # Resolve package name using python helper
     pkg=$(python3 "{this_script}" dummy dummy --get-pkg "$prefix" "$clean_v")
 
@@ -200,7 +200,7 @@ should_build() {{
 
     while i < len(lines):
         line = lines[i]
-        
+
         if "apt update" in line and not in_apt_group:
             new_lines.append('echo "::group::🔄 Installing System Dependencies (apt)"\n')
             in_apt_group = True
@@ -213,9 +213,9 @@ should_build() {{
             if in_apt_group:
                 new_lines.append('echo "::endgroup::"\n')
                 in_apt_group = False
-                
+
             tarball_expr = tarball_match.group(1)
-            
+
             # Extract a friendly name for the group header
             import re as _re
             base = _re.sub(r'\.tar\..*', '', tarball_expr)
@@ -223,7 +223,7 @@ should_build() {{
                 prefix = 'hwdata' if base.startswith('v') else 'seatd'
             else:
                 prefix = _re.sub(r'-[v0-9\$].*', '', base)
-            
+
             new_lines.append(line)
             new_lines.append(f'if should_build "{tarball_expr}"; then\n')
             new_lines.append(f'echo "::group::📦 Building {prefix} (from source)"\n')
@@ -284,25 +284,25 @@ if __name__ == "__main__":
 
     input_file = sys.argv[1]
     output_file = sys.argv[2]
-    
+
     if "--check-all" in sys.argv:
         with open(input_file, 'r') as f:
             content = f.read()
         dependencies = parse_dependencies(content)
         all_ok = True
-        
+
         # We know these are standard, anything else might be new
         known_prefixes = {"wayland", "wayland-protocols", "libdrm", "seatd", "pixman", "hwdata", "wlroots", "xserver-xwayland", "libdrm-libdrm", "pixman-pixman"}
-        
+
         print("::group::Dependency Verification (--check-all)")
         for prefix, version in dependencies:
             pkg = get_pkg_name(prefix, version)
             clean_v = version.lstrip('v')
             installed_ver = get_installed_version(pkg)
-            
+
             if prefix not in known_prefixes:
                 print(f"::warning::⚠️ NEW DEPENDENCY DETECTED in upstream script: {prefix} ({clean_v}) -> mapped to {pkg}")
-            
+
             if not check_dependency(pkg, clean_v):
                 if installed_ver:
                     print(f"::warning::🔄 VERSION BUMP DETECTED for {pkg}: installed {installed_ver}, needs >= {clean_v}")
@@ -311,7 +311,7 @@ if __name__ == "__main__":
             else:
                 print(f"✅ Dependency satisfied: {pkg} (installed {installed_ver})")
         print("::endgroup::")
-        
+
         sys.exit(0 if all_ok else 1)
 
     patch_script(input_file, output_file)

--- a/.github/scripts/run-coverage
+++ b/.github/scripts/run-coverage
@@ -12,7 +12,7 @@ mkdir -p "$XDG_CACHE_HOME/qtile"
 
 cleanup() {
     echo "Cleaning up processes..."
-    pkill -u "$USER" -9 qtile || true
+    pkill -9 qtile || true
     sudo pkill -9 -f "Xvfb $DISPLAY" || true
     rm -rf "$XDG_CACHE_HOME"
 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,10 +77,10 @@ jobs:
         run: cargo +${{ matrix.rust }} fmt -- --check
 
       - name: Cargo check
-        run: cargo +${{ matrix.rust }} check
+        run: cargo +${{ matrix.rust }} check --all-features --all-targets
 
       - name: Clippy
-        run: cargo +${{ matrix.rust }} clippy -- -D warnings
+        run: cargo +${{ matrix.rust }} clippy --all-features --all-targets -- -D warnings
 
       - name: Finalize sccache
         if: always() # Ensures it stops even if tests fail

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ env:
 
   # Tool paths
   UV_INSTALL_DIR: "/opt/hostedtoolcache/uv"
+  UV_CACHE_DIR: "/opt/hostedtoolcache/uv-cache"
   WAYLAND_INSTALL_DIR: "/opt/hostedtoolcache/qtile-deps/wayland/install"
   PKG_CONFIG_PATH: "/opt/hostedtoolcache/qtile-deps/wayland/install/lib/pkgconfig:/opt/hostedtoolcache/qtile-deps/wayland/install/share/pkgconfig"
   LD_LIBRARY_PATH: "/opt/hostedtoolcache/qtile-deps/wayland/install/lib"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,7 @@ jobs:
           rustup toolchain install stable nightly --profile minimal --no-self-update
           rustup default stable
           rustup component add llvm-tools
-          cargo install sccache
-          cargo install cargo-llvm-cov
+          cargo binstall -y sccache cargo-llvm-cov
 
       - name: Install System Deps
         run: ./.github/scripts/install-deps $(cat ./deps)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,9 +53,26 @@ jobs:
       - name: Install System Deps
         run: ./.github/scripts/install-deps $(cat ./deps)
 
+  pre-commit:
+    name: Pre-commit
+    needs: prepare
+    runs-on: qtile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: update GITHUB_PATH
+        run: |
+          echo "${{ env.CARGO_HOME }}/bin" >> $GITHUB_PATH
+          echo "${{ env.RUSTUP_HOME }}/bin" >> $GITHUB_PATH
+          echo "${{ env.UV_INSTALL_DIR }}/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Run pre-commit
+        run: uv tool run pre-commit run --all-files
+
   lint:
     name: Lint & Format (${{ matrix.rust }})
-    needs: prepare
+    needs: pre-commit
     runs-on: qtile
     env:
       RUSTC_WRAPPER: "sccache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -194,7 +194,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -220,15 +220,36 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "endian-type"
-version = "0.2.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "getrandom"
@@ -253,7 +274,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -294,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -436,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "radix_trie"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -462,14 +489,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 
 [[package]]
-name = "rustyline"
-version = "18.0.0"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
+ "fd-lock",
  "home",
  "libc",
  "log",
@@ -479,7 +520,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -566,7 +607,7 @@ dependencies = [
  "colored",
  "log",
  "time",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -835,11 +876,62 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -850,6 +942,102 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ simple_logger = "5.2.0"
 ctor = "*"
 sysinfo = "*"
 shellexpand = { version = "3.1.2", features = ["full", "path"] }
-rustyline = "18.0.0"
+rustyline = { version = "17.0.2", optional = true }
+
+[features]
+repl = ["dep:rustyline"]
 
 [[bin]]
 name = "qticc"

--- a/deps
+++ b/deps
@@ -55,3 +55,4 @@ xauth
 xserver-xephyr
 xwayland
 xvfb
+seatd

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,11 @@
 use anyhow::bail;
 use clap::Parser;
 pub(crate) mod utils;
+#[cfg(feature = "repl")]
+use utils::repl::Repl;
 use utils::{
     args::{Args, Commands},
     client::{CallResult, InteractiveCommandClient},
-    repl::Repl,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -43,6 +44,7 @@ fn main() -> anyhow::Result<()> {
             };
             Ok(())
         }
+        #[cfg(feature = "repl")]
         Commands::Repl => {
             let mut repl = Repl::new();
             repl.run()

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -47,5 +47,6 @@ pub enum Commands {
         json: bool,
     },
     /// Start an interactive REPL session.
+    #[cfg(feature = "repl")]
     Repl,
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,4 +13,5 @@ pub mod ipc;
 /// Translates CLI parameters into Qtile IPC JSON payloads
 pub mod parser;
 /// Interactive REPL mode
+#[cfg(feature = "repl")]
 pub mod repl;


### PR DESCRIPTION
## Summary

- Makes `rustyline` optional behind a `repl` feature flag (downgraded 18.0.0 → 17.0.2 to avoid a `home` version conflict with downstream consumers like qalttab#175)
- Gates `pub mod repl`, `use utils::repl::Repl`, and `Commands::Repl` behind `#[cfg(feature = "repl")]` so crates that don't need the REPL can omit the dependency entirely
- Minor pre-commit whitespace fixes in `.github/scripts/`