### PR TITLE
ci: upgrade actions to Node 24

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 0 * * 0' # Runs every Sunday at midnight
   workflow_dispatch: # Allows you to run it manually
 
+env:
+  # Node.js 20 is deprecated. Force Node.js 24 for all JavaScript actions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cleanup:
     runs-on: qtile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,16 @@ on:
     tags:
       - 'v*'
 
+env:
+  # Node.js 20 is deprecated. Force Node.js 24 for all JavaScript actions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build Release Binary
     runs-on: qtile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -22,7 +26,7 @@ jobs:
         run: cargo build --release
 
       - name: Create GitHub Release and Upload Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: target/release/qticc
           generate_release_notes: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,9 @@ env:
   QTILE_REPO: "https://github.com/qtile/qtile.git"
   QTILE_BRANCH: "master"
 
+  # Node.js 20 is deprecated. Force Node.js 24 for all JavaScript actions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare:
     name: Prepare toolcache
@@ -35,7 +38,7 @@ jobs:
       group: pvc-toolcache-lock
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: update GITHUB_PATH
         run: |
@@ -54,7 +57,7 @@ jobs:
     needs: prepare
     runs-on: qtile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: update GITHUB_PATH
         run: |
@@ -77,7 +80,7 @@ jobs:
       matrix:
         rust: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: update GITHUB_PATH
         run: |
@@ -114,7 +117,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         rust: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: update GITHUB_PATH
         run: |
@@ -159,7 +162,7 @@ jobs:
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Network Pre-flight
         run: until timeout 1 bash -c "cat < /dev/null > /dev/tcp/github.com/443"; do sleep 5; done
@@ -189,7 +192,7 @@ jobs:
         run: ./.github/scripts/run-coverage
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/llvm-cov/lcov.info


### PR DESCRIPTION
Fixes the GitHub Actions Node.js 20 deprecation warnings by:

- Upgrading `actions/checkout` to v6
- Upgrading `codecov/codecov-action` to v6
- Upgrading `softprops/action-gh-release` to v3
- Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` across workflows