### PR TITLE
fix(ci): scope prepare concurrency lock per PR/branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
     name: Prepare toolcache
     runs-on: qtile
     concurrency:
-      group: pvc-toolcache-lock
+      group: pvc-toolcache-lock-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Changes `concurrency.group` in the `prepare` job from the global `pvc-toolcache-lock` to `pvc-toolcache-lock-<PR number or branch name>`
- Prevents "Canceling since a higher priority waiting request exists" errors when multiple workflow runs are queued at the same time
- Each PR/branch now gets its own serialization slot; different PRs no longer block or cancel each other

## Root cause

With a single global concurrency group and `cancel-in-progress: false`, GitHub Actions only allows one job running + one job pending per group. A third run arriving cancels the pending one, causing CI failures for any run that isn't the newest.

## Test plan

- [ ] Open two additional test PRs (`test/ci-concurrent-1`, `test/ci-concurrent-2`) simultaneously with this one
- [ ] Verify all three `prepare` jobs run concurrently without canceling each other
- [ ] Verify subsequent jobs (`pre-commit`, `lint`, `test`, `coverage`) complete for all three PRs