### PR TITLE
fix(ci): flock the shared toolchain install to stop concurrent-PR races

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,17 @@ jobs:
           echo "${{ env.RUSTUP_HOME }}/bin" >> $GITHUB_PATH
 
       - name: Setup Rust & tools
+        # RUSTUP_HOME/CARGO_HOME live on a ReadWriteMany PVC shared by every
+        # runner pod. Concurrent PRs each running `prepare` at the same time
+        # race on the same toolchain download dir (e.g. on a stable/nightly
+        # channel bump, which redownloads all components) and fail with
+        # "could not rename ... .partial file: No such file or directory".
+        # flock serializes this section across pods so they queue instead of
+        # racing; the per-PR `concurrency:` group above doesn't help since it
+        # only serializes runs for the *same* PR/branch.
         run: |
+          exec 200>/opt/hostedtoolcache/.rustup-toolchain.lock
+          flock -w 300 200
           rustup toolchain install stable nightly --profile minimal --no-self-update
           rustup default stable
           rustup component add llvm-tools


### PR DESCRIPTION
## Summary
- Concurrent `prepare` jobs (from different PRs/branches) share the same `RUSTUP_HOME`/`CARGO_HOME` on the `ReadWriteMany` tool-cache PVC.
- When two jobs run `rustup toolchain install` at the same time — e.g. right after a stable/nightly channel bump, which forces a full component re-download — they race on the same `.partial` download files and fail with `could not rename ... .partial file: No such file or directory`.
- The existing per-PR `concurrency:` group doesn't help, since it only serializes runs for the *same* PR/branch, not across different ones.
- Wraps the `rustup`/`cargo binstall` section in a `flock` keyed to a lock file on the shared PVC, so concurrent pods queue for this ~30-90s section instead of racing.

Confirmed via runs [29161184279 (PR 186)](https://github.com/ervinpopescu/qtile-cmd-client/actions/runs/29161184279/job/86566429004) and 29161187904 (PR 187), both opened by the same Dependabot batch — their `prepare` jobs failed in the same second on *different* components (`llvm-tools` vs `cargo`), confirming a genuine concurrent-write race rather than a one-off download hiccup.

## Test plan
- [ ] Open two PRs (or push to two branches) at roughly the same time to trigger overlapping `prepare` jobs, confirm both succeed (one may wait briefly on the lock instead of failing)
- [ ] Confirm normal single-PR CI runs are unaffected (no meaningful added latency)