### PR TITLE
fix(ci): robust rustup install to handle NFS rename and doc conflicts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,9 @@ jobs:
           fi
 
           rustup default stable
-          rustup component add llvm-tools
+          rustup component add rustfmt clippy --toolchain stable
+          rustup component add rustfmt clippy --toolchain nightly
+          rustup component add llvm-tools --toolchain stable
           cargo binstall -y sccache cargo-llvm-cov
 
   pre-commit:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,22 @@ jobs:
         run: |
           exec 200>/opt/hostedtoolcache/.rustup-toolchain.lock
           flock -w 300 200
-          rustup toolchain install stable nightly --profile minimal --no-self-update
+
+          # Clean up any residual doc or zsh completion directories that cause NFS rename failures
+          # and remove rust-docs which is extremely slow to extract and unused in CI.
+          rustup component remove rust-docs --toolchain stable || true
+          rustup component remove rust-docs --toolchain nightly || true
+          rm -rf /opt/hostedtoolcache/rustup/toolchains/*/share/doc
+          rm -rf /opt/hostedtoolcache/rustup/toolchains/*/share/zsh
+          rm -rf /opt/hostedtoolcache/rustup/tmp/*
+
+          if ! rustup toolchain install stable nightly --profile minimal --no-self-update; then
+            echo "Toolchain install failed. Cleaning up and retrying with a fresh slate..."
+            rm -rf /opt/hostedtoolcache/rustup/toolchains/*
+            rm -rf /opt/hostedtoolcache/rustup/tmp/*
+            rustup toolchain install stable nightly --profile minimal --no-self-update
+          fi
+
           rustup default stable
           rustup component add llvm-tools
           cargo binstall -y sccache cargo-llvm-cov


### PR DESCRIPTION
This PR fixes a bug in the CI prepare job where rustup toolchain installation fails on NFS-backed self-hosted runners due to directory-not-empty rename issues and rust-docs conflicts. It cleans up conflicting directories (such as share/doc and share/zsh), removes rust-docs to avoid extraction/conflict errors, and implements robust retry logic to clear and reset the toolchain cache if the installation fails.